### PR TITLE
first 2.x cut

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+sudo: required
+before_script:
+  - npm install -g polymer-cli
+  - polymer install
+node_js: stable
+addons:
+  firefox: latest
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
+script:
+  - xvfb-run -s '-screen 0 1024x768x24' polymer test
+dist: trusty

--- a/array-filter.html
+++ b/array-filter.html
@@ -47,61 +47,68 @@ For this reason, you can use the `observe` propert.
 In the example, any time the `name` property of a child changes, the sort
 and filter state will be recomputed.
 
-@demo demo/index.html 
+@demo demo/index.html
 -->
 
-<dom-module id="array-filter">
-    <script>
-        Polymer({
-            is: 'array-filter',
+<script>
+    (function() {
+        class ArrayFilter extends Polymer.Element {
+            static get properties() {
+                return {
+                    /*
+                     * An array containing items to be filtered/sorted
+                     */
+                    items: {
+                        type: Array,
+                        notify: true
+                    },
+                    /*
+                     * The `items` array after having any filter/sort applied
+                     */
+                    filtered: {
+                        type: Array,
+                        notify: true
+                    },
+                    /*
+                     * A space-separated list of paths to observe in children.
+                     * When one or more of these paths change in a child, the
+                     * child will be re-sorted/re-filtered.
+                     */
+                    observe: {
+                        type: String
+                    },
+                    /*
+                     * A function or the name of a method to be used for
+                     * filtering the `items` array.
+                     */
+                    filter: {
+                        type: Function,
+                        observer: '_filterChanged'
+                    },
+                    /*
+                     * A function or the name of a method to be used for
+                     * sorting the `items` array.
+                     */
+                    sort: {
+                        type: Function,
+                        observer: '_sortChanged'
+                    }
+                };
+            }
 
-            properties: {
-                /*
-                 * An array containing items to be filtered/sorted
-                 */
-                items: {
-                    type: Array,
-                    notify: true
-                },
-                /*
-                 * The `items` array after having any filter/sort applied
-                 */
-                filtered: {
-                    type: Array,
-                    notify: true
-                },
-                /*
-                 * A space-separated list of paths to observe in children.
-                 * When one or more of these paths change in a child, the
-                 * child will be re-sorted/re-filtered.
-                 */
-                observe: {
-                    type: String
-                },
-                /*
-                 * A function or the name of a method to be used for
-                 * filtering the `items` array.
-                 */
-                filter: {
-                    type: Function,
-                    observer: '_filterChanged'
-                },
-                /*
-                 * A function or the name of a method to be used for
-                 * sorting the `items` array.
-                 */
-                sort: {
-                    type: Function,
-                    observer: '_sortChanged'
-                }
-            },
+            static get observers() {
+                return [
+                    '_itemsChanged(items.*)'
+                ];
+            }
 
-            observers: [
-                '_itemsChanged(items.*)'
-            ],
+            constructor() {
+                super();
+                this._filterDebouncer = null;
+            }
 
-            _sortChanged: function(val) {
-                var host = this.domHost;
+            _sortChanged(val) {
+                var host = this.getRootNode().host;
                 var sort = val;
 
                 if(!sort) {
@@ -119,14 +126,17 @@ and filter state will be recomputed.
                 if(this.items) {
                     this._debounceFilter();
                 }
-            },
+            }
 
-            _debounceFilter: function() {
-                this.debounce('_filter', this._filter);
-            },
+            _debounceFilter() {
+                this._filterDebouncer = Polymer.Debouncer.debounce(
+                    this._filterDebouncer,
+                    Polymer.Async.microTask,
+                    this._filter.bind(this));
+            }
 
-            _filterChanged: function(val) {
-                var host = this.domHost;
+            _filterChanged(val) {
+                var host = this.getRootNode().host;
                 var filter = val;
 
                 if(!filter) {
@@ -144,9 +154,9 @@ and filter state will be recomputed.
                 if(this.items) {
                     this._debounceFilter();
                 }
-            },
+            }
 
-            _itemsChanged: function(change) {
+            _itemsChanged(change) {
                 var path = change.path;
 
                 if(path === 'items') {
@@ -157,40 +167,36 @@ and filter state will be recomputed.
                 } else {
                     this._checkSort(change.path);
                 }
-            },
+            }
 
-            _resetLinks: function() {
+            _resetLinks() {
                 if(this.filtered) {
-                    var filteredCollection = Polymer.Collection.get(this.filtered);
-                    var itemsCollection = Polymer.Collection.get(this.items);
                     var item, idx;
                     for(var i = 0; i < this.filtered.length; i++) {
                         item = this.filtered[i];
-                        idx = filteredCollection.getKey(item);
-
-                        this.unlinkPaths('filtered.' + idx);
+                        this.unlinkPaths('filtered.' + i);
                         this.linkPaths(
-                            'filtered.' + idx,
-                            'items.' + itemsCollection.getKey(item)
+                            'filtered.' + i,
+                            'items.' + this.items.indexOf(item)
                         );
                     }
                 }
-            },
+            }
 
-            _filter: function() {
+            _filter() {
                 this.filtered = this._computeFiltered(this.items);
                 this._resetLinks();
-            },
+            }
 
             /*
              * Forces filter/sort to be re-applied asynchronously
              * @method update
              */
-            update: function() {
+            update() {
                 this._debounceFilter();
-            },
+            }
 
-            _computeFiltered: function(base) {
+            _computeFiltered(base) {
                 if(!base) {
                     return;
                 }
@@ -206,16 +212,17 @@ and filter state will be recomputed.
                 }
 
                 return result;
-            },
+            }
 
-            _computeSplices: function(keys, index) {
+            _computeSplices(keys, index) {
                 index.forEach(function(splice) {
                     var filtered = this._computeFiltered(splice.object);
                     var inserts = [];
                     var item;
 
                     splice.removed.forEach(function(remove) {
-                        this.arrayDelete('filtered', remove);
+                        this.splice('filtered',
+                            this.filtered.indexOf(remove), 1);
                     }.bind(this));
 
                     for(var i = 0; i < splice.addedCount; i++) {
@@ -233,22 +240,19 @@ and filter state will be recomputed.
                 }.bind(this));
 
                 this._resetLinks();
-            },
+            }
 
-            _applyObserver: function(path) {
+            _applyObserver(path) {
                 var parts = path.split('.');
                 var filtered = this._computeFiltered(this.items);
-                var filteredCollection = Polymer.Collection.get(this.filtered);
-                var itemsCollection = Polymer.Collection.get(this.items);
-                var item = itemsCollection.getItem(parts[1]);
+                var item = this.items[parseInt(parts[1])];
                 var currentIdx = this.filtered.indexOf(item);
                 var newIdx = filtered.indexOf(item);
 
                 if(currentIdx !== newIdx) {
                     if(currentIdx !== -1) {
-                        var currentColIdx = filteredCollection.getKey(item);
-                        this.unlinkPaths('filtered.' + currentColIdx);
-                        this.arrayDelete('filtered', item);
+                        this.unlinkPaths('filtered.' + currentIdx);
+                        this.splice('filtered', currentIdx, 1);
                     }
 
                     if(newIdx !== -1) {
@@ -262,9 +266,9 @@ and filter state will be recomputed.
                 }
 
                 this._resetLinks();
-            },
+            }
 
-            _checkSort: function(path) {
+            _checkSort(path) {
                 var parts = path.split('.');
                 var key = parts[1];
 
@@ -286,6 +290,7 @@ and filter state will be recomputed.
                     }
                 }
             }
-        });
-    </script>
-</dom-module>
+        }
+        customElements.define('array-filter', ArrayFilter);
+    })();
+</script>

--- a/bower.json
+++ b/bower.json
@@ -4,12 +4,12 @@
     "main": "array-filter.html",
     "version": "1.0.2",
     "dependencies": {
-        "polymer": "Polymer/polymer#^1.4.0"
+        "polymer": "Polymer/polymer#^2.0.0"
     },
     "devDependencies": {
-        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-        "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
-        "web-component-tester": "^4.0.0",
-        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+        "iron-component-page": "PolymerElements/iron-component-page#^2.0.0",
+        "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
+        "web-component-tester": "^6.0.0",
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.1"
     }
 }

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
     "name": "array-filter",
     "description": "Provides the ability to filter/sort an array and maintain bindings",
     "main": "array-filter.html",
-    "version": "1.0.2",
+    "version": "2.0.0",
     "dependencies": {
         "polymer": "Polymer/polymer#^2.0.0"
     },

--- a/test/basic.html
+++ b/test/basic.html
@@ -32,10 +32,6 @@
                     ];
                 });
 
-                test('instantiating the element works', function() {
-                    assert.equal(el.is, 'array-filter');
-                });
-
                 test('simple pass-through filtering', function(done) {
                     flush(function() {
                         assert.equal(el.filtered.length, 5);
@@ -130,7 +126,7 @@
 
                 test('sub-property changes', function(done) {
                     flush(function() {
-                        el.set('items.#0.name', 'charlie');
+                        el.set('items.0.name', 'charlie');
                         assert.equal(el.filtered[0].name, 'charlie');
                         done();
                     });
@@ -143,11 +139,11 @@
 
                     flush(function() {
                         assert.equal(el.filtered.length, 4);
-                        el.set('items.#0.name', 'bobby');
+                        el.set('items.0.name', 'bobby');
                         flush(function() {
                             assert.equal(el.filtered.length, 5);
                             assert.equal(el.filtered[2].name, 'bobby');
-                            el.set('items.#0.name', 'zeus');
+                            el.set('items.0.name', 'zeus');
                             flush(function() {
                                 assert.equal(el.filtered[2].name, 'frank');
                                 assert.equal(el.filtered[4].name, 'zeus');


### PR DESCRIPTION
Converted to a 2.0 class...

* Have not opted for the "hybrid" form that most official elements seem to use
* Removed any collections and their associated keypaths (`#n`, as AFAIK 2.0 has no such concept anymore)
* Updated all dependencies to their latest versions
* Removed the `is()` assertion (there isn't an `is` anymore, as it has no dom-module)
* Removed dom-module