### PR TITLE
remap linked paths via items instead of filtered

### DIFF
--- a/array-filter.html
+++ b/array-filter.html
@@ -172,13 +172,16 @@ and filter state will be recomputed.
             _resetLinks() {
                 if(this.filtered) {
                     var item, idx;
-                    for(var i = 0; i < this.filtered.length; i++) {
-                        item = this.filtered[i];
-                        this.unlinkPaths('filtered.' + i);
-                        this.linkPaths(
-                            'filtered.' + i,
-                            'items.' + this.items.indexOf(item)
-                        );
+                    for(var i = 0; i < this.items.length; i++) {
+                        item = this.items[i];
+                        this.unlinkPaths('items.' + i);
+                        idx = this.filtered.indexOf(item);
+                        if(idx !== -1) {
+                            this.linkPaths(
+                                'items.' + i,
+                                'filtered.' + idx
+                            );
+                        }
                     }
                 }
             }

--- a/test/basic.html
+++ b/test/basic.html
@@ -132,6 +132,35 @@
                     });
                 });
 
+                test('filtered sub-property changes', function(done) {
+                    el.filter = item => item.name.indexOf('b') === 0;
+                    el.observe = 'name';
+
+                    flush(function() {
+                        el.set('items.2.name', 'bill');
+                        assert.equal(el.filtered[2].name, 'bill');
+                        el.set('items.2.name', 'bill1');
+                        assert.equal(el.filtered[2].name, 'bill1');
+                        done();
+                    });
+                });
+
+                test('force update', function(done) {
+                    let filterText = null;
+                    el.filter = item => !filterText || item.name.indexOf(filterText) === 0;
+                    el.observe = 'name';
+
+                    flush(function() {
+                        assert.equal(el.filtered.length, 5);
+                        filterText = 'b';
+                        el.update();
+                        flush(function() {
+                            assert.equal(el.filtered.length, 2);
+                            done();
+                        });
+                    });
+                });
+
                 test('single property observer', function(done) {
                     el.observe = 'name';
                     el.sort = (a, b) => a.name < b.name ? -1 : 1;
@@ -153,8 +182,7 @@
                     });
                 });
 
-                test('multiple property observer', function() {
-                });
+                test('multiple property observer');
 
                 test('pushing to array', function(done) {
                     el.sort = (a, b) => a.name < b.name ? -1 : 1;


### PR DESCRIPTION
Fixes #11.

This is done by linking paths from items to filtered rather than the
opposite. This way we can no longer end up with stale links.

We are missing a test case here, too. The problem was that the data had changed but polymer's cache of it had not. So any tests would pass as the data being asserted against was correct... Other than testing DOM values im not sure how this would be covered.